### PR TITLE
feat: add prettier precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
+      "prettier --write",
       "eslint --fix"
     ]
   },


### PR DESCRIPTION
Pre-commit の ESLint の前に Prettier を追加しました。

## Description

### 変更前

js, ts, jsx, tsx のコミット時に、ESLintを通す。

### 変更後

js, ts, jsx, tsx のコミット時に、Prettier → ESLintの順に通すようにした。

## Related Issues

#249 